### PR TITLE
Introduce break line after buildpack output

### DIFF
--- a/build.go
+++ b/build.go
@@ -13,6 +13,7 @@ func Build(logger scribe.Logger) packit.BuildFunc {
 
 		logger.Process("Assigning launch processes")
 		logger.Subprocess("web: %s", command)
+		logger.Break()
 
 		return packit.BuildResult{
 			Launch: packit.LaunchMetadata{


### PR DESCRIPTION
Not sure if this is intended, but it looks like the other buildpacks introduce a breakline in the logs inside `Build()` but puma does not.

- [yarn-install](https://github.com/paketo-buildpacks/yarn-install/blob/20edf8b86d9b0ef76590555ba15e1463efd6db12/build.go#L91)
- [passenger](https://github.com/paketo-buildpacks/passenger/blob/d15501004d0573158e96278cc9ed560fefb67fb8/build.go#L47)

```
Paketo Bundler Buildpack 0.0.153
  Resolving Bundler version
    Candidate version sources (in priority order):
      Gemfile.lock -> "2.1.4"
      <unknown>    -> "*"
      <unknown>    -> "*"
      <unknown>    -> "*"

    Selected Bundler version (using Gemfile.lock): 2.1.4

  Executing build process
    Installing Bundler 2.1.4
      Completed in 194ms

  Configuring environment
    GEM_PATH -> "$GEM_PATH:/layers/paketo-buildpacks_bundler/bundler"

Paketo Bundle Install Buildpack 0.1.2
  Executing build process
    Running 'bundle config path /layers/paketo-buildpacks_bundle-install/gems'
    Running 'bundle config clean true'
    Running 'bundle config cache_path --parseable'
    Running 'bundle install --local'
      Completed in 2m42.728s

  Configuring environment
    BUNDLE_PATH -> "/layers/paketo-buildpacks_bundle-install/gems"

Paketo Puma Buildpack 0.0.53
  Assigning launch processes
    web: bundle exec puma --bind tcp://0.0.0.0:${PORT:-9292}
Paketo Rails Assets Buildpack 0.0.5
  Executing build process
    Running 'bundle exec rails assets:precompile assets:clean'
      Completed in 3.811s

```

Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change enables:

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
