### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/puma"
   id = "paketo-buildpacks/puma"
   keywords = ["ruby", "puma"]
-  name = "Paketo Puma Buildpack"
+  name = "Paketo Buildpack for Puma"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Puma Buildpack' to 'Paketo Buildpack for Puma'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
